### PR TITLE
Fix LL provider error

### DIFF
--- a/JS/ServiceAPI/serviceAPI.js
+++ b/JS/ServiceAPI/serviceAPI.js
@@ -94,7 +94,8 @@
                 }
                 else if (login.loginType === LoginTypes.OIDC) {
                   xhr.setRequestHeader("Authorization", "Basic " + login.getBasicAuthLogin());
-                  return xhr.setRequestHeader("access-token", login.getAccessToken());
+				  xhr.setRequestHeader("access-token", login.getAccessToken());
+                  return xhr.setRequestHeader("oidc_provider", "https://auth.las2peer.org/o/oauth2");
                 }
               }
             };


### PR DESCRIPTION
Explicitly mention new LL provider in request header, since default provider of old l2p version is deprecated